### PR TITLE
Remove `fetch=False` unsupported keyword from DB.iter{items,keys,values} documentation

### DIFF
--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -138,7 +138,7 @@ Database object
             * ``(True, <data>)`` if key is found and value in memory and ``fetch=True``
             * ``(False, None)`` if key is not found
 
-    .. py:method:: iterkeys(fetch=False, verify_checksums=False, fill_cache=True, snapshot=None, read_tier="all")
+    .. py:method:: iterkeys(verify_checksums=False, fill_cache=True, snapshot=None, read_tier="all")
 
         Iterate over the keys
 
@@ -150,7 +150,7 @@ Database object
 
         :rtype: :py:class:`rocksdb.BaseIterator`
 
-    .. py:method:: itervalues(fetch=False, verify_checksums=False, fill_cache=True, snapshot=None, read_tier="all")
+    .. py:method:: itervalues(verify_checksums=False, fill_cache=True, snapshot=None, read_tier="all")
 
         Iterate over the values
 
@@ -162,7 +162,7 @@ Database object
 
         :rtype: :py:class:`rocksdb.BaseIterator`
 
-    .. py:method:: iteritems(fetch=False, verify_checksums=False, fill_cache=True, snapshot=None, read_tier="all")
+    .. py:method:: iteritems(verify_checksums=False, fill_cache=True, snapshot=None, read_tier="all")
 
         Iterate over the items
 


### PR DESCRIPTION
```python
>>> import rocksdb as r
>>> d = r.DB('/tmp/bla', r.Options(create_if_missing=True))
>>> d.iterkeys(fetch=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "rocksdb/_rocksdb.pyx", line 1594, in rocksdb._rocksdb.DB.iterkeys
  File "rocksdb/_rocksdb.pyx", line 1700, in rocksdb._rocksdb.DB.__parse_read_opts
TypeError: __parse_read_opts() got an unexpected keyword argument 'fetch'
```