### PR TITLE
Docs: Exporting CPLUS_INCLUDE_PATH, LD_LIBRARY_PATH and LIBRARY_PATH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Quick install for debian/ubuntu like linux distributions.
 
 .. code-block:: bash
 
-    $ apt-get install build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev
+    $ apt-get install build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev
     $ git clone https://github.com/facebook/rocksdb.git
     $ cd rocksdb
     $ mkdir build && cd build

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,11 @@ Quick install for debian/ubuntu like linux distributions.
     $ mkdir build && cd build
     $ cmake ..
     $ make
-    $ export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:`pwd`/../include
-    $ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`
-    $ export LIBRARY_PATH=${LIBRARY_PATH}:`pwd`
+    $ cd ..
+    $ export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+:}`pwd`/include/
+    $ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}`pwd`/build/
+    $ export LIBRARY_PATH=${LIBRARY_PATH}${LIBRARY_PATH:+:}`pwd`/build/
 
-    $ cd ../
     $ apt-get install python-virtualenv python-dev
     $ virtualenv pyrocks_test
     $ cd pyrocks_test


### PR DESCRIPTION
correctly even if they weren't originally assigned.

As it stands, the exports prepend an illegal ':' causing installation of python-rocksdb to fail citing a missing header file. Understandable since it was never discovered at the wrong path assigned to the variables.