### PR TITLE
Allow `rocksdb.DB` instances to be manually closed

### DIFF
--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -1449,14 +1449,18 @@ cdef class DB(object):
 
         self.opts = opts
         self.opts.in_use = True
-
-    def __dealloc__(self):
+    
+    def close(self):
         if not self.db == NULL:
             with nogil:
                 del self.db
+                self.db = NULL
 
         if self.opts is not None:
             self.opts.in_use = False
+    
+    def __dealloc__(self):
+        self.close()
 
     def put(self, key, value, sync=False, disable_wal=False):
         cdef Status st


### PR DESCRIPTION
While `delete rocks_ptr` is a deterministic operation in C++, the Python analogue `del rocks_handle` is not – disposal and finalization of the Rocks database are entirely dependent on the Python garbage collector (q.v. the `python-rocksdb` tests themselves, which call `gc.collect()` after `del rocks_handle` to attempt to force the destructor to run).

This change exposes a method to trigger the destruction of the underlying Rocks database pointer (deterministic!) through the Python Rocks handle; existing code will not need to be changed, as the Python object destructor (non-deterministic!) will now call this method.