### PR TITLE
Allow `rocksdb.DB` instances to be manually closed (second revision PR)

### DIFF
--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -1671,6 +1671,9 @@ cdef class DB(object):
         self.opts.in_use = True
 
     def __dealloc__(self):
+        self.close()
+        
+    def close(self):
         cdef ColumnFamilyOptions copts
         if not self.db == NULL:
             # We have to make sure we delete the handles so rocksdb doesn't


### PR DESCRIPTION
While `delete rocks_ptr` is a deterministic operation in C++, the Python analogue `del rocks_handle` is not – disposal and finalization of the Rocks database are entirely dependent on the Python garbage collector (q.v. the `python-rocksdb` tests themselves, which call `gc.collect()` after `del rocks_handle` to attempt to force the destructor to run):

https://github.com/twmht/python-rocksdb/blob/98910c2dce41c02aaa1745ae09e9d5fcdde34bdd/rocksdb/tests/test_db.py#L14-L21

This change exposes a method to trigger the destruction of the underlying Rocks database pointer (deterministic!) through the Python Rocks handle; existing code will not need to be changed, as the Python object destructor (non-deterministic!) will now call this method.

This is the second revision of this PR – it resolves the first revision, #39, and would close issue #10.