### PR TITLE
Fix for python 2.7: Exception AttributeError: "'list' object has no a…

### DIFF
--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -1672,7 +1672,7 @@ cdef class DB(object):
 
     def __dealloc__(self):
         self.close()
-        
+
     def close(self):
         cdef ColumnFamilyOptions copts
         if not self.db == NULL:
@@ -1682,7 +1682,7 @@ cdef class DB(object):
             for copts in self.cf_options:
                 if copts:
                     copts.in_use = False
-            self.cf_options.clear()
+            self.cf_options = []
 
             with nogil:
                 del self.db


### PR DESCRIPTION
AttributeError: 'list' object has no attribute 'clear'
Exception AttributeError: "'list' object has no attribute 'clear'" in 'rocksdb._rocksdb.DB.__dealloc__' ignored