### PR TITLE
Fix for PyPy install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import platform
 from setuptools import setup
 from setuptools import find_packages
 from setuptools import Extension
-
+import os
 
 extra_compile_args = [
     '-std=c++11',
@@ -14,10 +14,20 @@ extra_compile_args = [
     '-fno-rtti',
 ]
 
+
 if platform.system() == 'Darwin':
     extra_compile_args += ['-mmacosx-version-min=10.7', '-stdlib=libc++']
+    from distutils.sysconfig import get_config_var
+    from distutils.version import LooseVersion
+    if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+        current_system = LooseVersion(platform.mac_ver()[0])
+        python_target = LooseVersion(
+            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if python_target < '10.9' and current_system >= '10.9':
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
-
+    
+            
 setup(
     name="python-rocksdb",
     version='0.7.0',


### PR DESCRIPTION
`clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9`
This error pops up only when install via pip_pypy, Python was fine, now both should work like a charm.

Test before merge.