### PR TITLE
Fixed segfault on DB close

### DIFF
--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -1672,20 +1672,19 @@ cdef class DB(object):
 
     def __dealloc__(self):
         self.close()
-        
+        if not self.db == NULL:
+            del self.db
+
     def close(self):
         cdef ColumnFamilyOptions copts
         if not self.db == NULL:
             # We have to make sure we delete the handles so rocksdb doesn't
-            # assert when we delete the db
+            # assert when we delete the db.
             self.cf_handles.clear()
             for copts in self.cf_options:
                 if copts:
                     copts.in_use = False
             self.cf_options.clear()
-
-            with nogil:
-                del self.db
 
         if self.opts is not None:
             self.opts.in_use = False

--- a/rocksdb/db.pxd
+++ b/rocksdb/db.pxd
@@ -55,6 +55,8 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
         Range(const Slice&, const Slice&)
 
     cdef cppclass DB:
+        Status Close() nogil except+
+
         Status Put(
             const options.WriteOptions&,
             ColumnFamilyHandle*,
@@ -203,3 +205,8 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
             const options.ColumnFamilyOptions&) nogil except+
         string name
         options.ColumnFamilyOptions options
+
+cdef extern from "rocksdb/convenience.h" namespace "rocksdb":
+    void CancelAllBackgroundWork(
+        DB* db,
+        cpp_bool wait) nogil except+

--- a/rocksdb/db.pxd
+++ b/rocksdb/db.pxd
@@ -201,7 +201,7 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
     cdef cppclass ColumnFamilyDescriptor:
         ColumnFamilyDescriptor() nogil except+
         ColumnFamilyDescriptor(
-	    const string&,
+        const string&,
             const options.ColumnFamilyOptions&) nogil except+
         string name
         options.ColumnFamilyOptions options


### PR DESCRIPTION
Close DB when `close` is called, and free DB object only in destructor (in line with Cython guidelines).

Fixes #91.